### PR TITLE
llc only supports one input file

### DIFF
--- a/example04/CMakeLists.txt
+++ b/example04/CMakeLists.txt
@@ -1,0 +1,17 @@
+# cmake file
+
+cmake_minimum_required(VERSION 3.9)
+
+find_program(CMAKE_C_COMPILER clang)
+find_program(CMAKE_CXX_COMPILER clang++)
+
+project(staticlib)
+
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../cmake")
+
+message(STATUS ${CMAKE_MODULE_PATH})
+include(LLVMIRUtil)
+
+add_subdirectory(staticlib)
+add_subdirectory(executable)
+

--- a/example04/README.txt
+++ b/example04/README.txt
@@ -1,0 +1,9 @@
+# Instrumenting an static library
+
+```sh
+mkdir build && cd build
+cmake ..
+make testlib_instrumented
+make main
+./executable/main
+```

--- a/example04/executable/CMakeLists.txt
+++ b/example04/executable/CMakeLists.txt
@@ -1,0 +1,3 @@
+add_executable(main main.c)
+target_include_directories(main PUBLIC "./../staticlib/include")
+target_link_libraries(main "${CMAKE_BINARY_DIR}/staticlib/libtestlib_instrumented.a")

--- a/example04/executable/main.c
+++ b/example04/executable/main.c
@@ -1,0 +1,8 @@
+#include "Test1.h"
+
+int main(int argc, char **argv)
+{
+  puts("Calling Test1 from static lib!");
+  Test1();
+  return 0;
+}

--- a/example04/staticlib/CMakeLists.txt
+++ b/example04/staticlib/CMakeLists.txt
@@ -1,0 +1,18 @@
+set(CMAKE_BUILD_TYPE Debug)
+# set(LLVM_PASS_PLUGIN "<filepath to llvm plugin pass>")
+
+set(SOURCE_FILES
+  src/Test1.c
+  src/Test2.c
+  src/Test3.c
+)
+
+add_library(testlib STATIC ${SOURCE_FILES})
+target_include_directories(testlib PUBLIC "./include")
+set_target_properties(testlib PROPERTIES LINKER_LANGUAGE C)
+
+llvmir_attach_bc_target(testlib_bc testlib)
+llvmir_attach_opt_pass_target(testlib_opt testlib_bc) # -load-pass-plugin=${LLVM_PASS_PLUGIN} -passes=ctrace)
+
+llvmir_attach_obj_target(testlib_obj testlib_opt)
+llvmir_attach_library(testlib_instrumented testlib_obj STATIC)

--- a/example04/staticlib/include/Test1.h
+++ b/example04/staticlib/include/Test1.h
@@ -1,0 +1,4 @@
+#include <stdlib.h>
+#include "Test2.h"
+
+void Test1();

--- a/example04/staticlib/include/Test2.h
+++ b/example04/staticlib/include/Test2.h
@@ -1,0 +1,4 @@
+#include "Test3.h"
+#include <stdio.h>
+
+void Test2();

--- a/example04/staticlib/include/Test3.h
+++ b/example04/staticlib/include/Test3.h
@@ -1,0 +1,3 @@
+#include <stdio.h>
+
+void Test3();

--- a/example04/staticlib/src/Test1.c
+++ b/example04/staticlib/src/Test1.c
@@ -1,0 +1,7 @@
+#include "Test1.h"
+
+void Test1()
+{
+  puts("Test1 called");
+  Test2();
+}

--- a/example04/staticlib/src/Test2.c
+++ b/example04/staticlib/src/Test2.c
@@ -1,0 +1,7 @@
+#include "Test2.h"
+
+void Test2()
+{
+  puts("Test2 called!");
+  Test3();
+}

--- a/example04/staticlib/src/Test3.c
+++ b/example04/staticlib/src/Test3.c
@@ -1,0 +1,6 @@
+#include "Test3.h"
+
+void Test3()
+{
+  puts("Test3 called");
+}


### PR DESCRIPTION
When the target library is compiled to a static library with the following CMAKE options:

```cmake
add_library(testbase STATIC ${SOURCE_FILES})
llvmir_attach_bc_target(testbase_bc testbase)
llvmir_attach_opt_pass_target(testbase_opt testbase_bc -load-pass-plugin=${LLVM_PASS_CTRACE} -passes=ctrace)
llvmir_attach_obj_target(testbase_obj testbase_opt)
llvmir_attach_library(testbase_instrumented testbase_obj STATIC)
```

I got the following error message:
```
FAILED: llvm-ir/testbase_obj/testbase_obj.o /[...]/build/llvm-ir/testbase_obj/testbase_obj.o
cd /[...]/build && llc -filetype=obj -o /[...]/build/llvm-ir/testbase_obj/testbase_obj.o /[...]/build/llvm-ir/testbase_opt/Test1.bc /[...]/build/llvm-ir/testbase_opt/Test2.bc /[...]/build/llvm-ir/testbase_opt/Test3.bc /[...]/build/llvm-ir/testbase_opt/Test4.bc
llc: Too many positional arguments specified!
Can specify at most 1 positional arguments: See: llc --help
ninja: build stopped: subcommand failed.
```

The problem is that LLC only supports one input file. This PR fixes this issue by going over each bc file separately.